### PR TITLE
fixed issue of multiple items with same key in ProductOverview pages

### DIFF
--- a/src/components/ProductOverview.js
+++ b/src/components/ProductOverview.js
@@ -243,7 +243,7 @@ export default function ProductOverview({
               {/* FEATURES SECTION */}
               <div className="divide-y divide-gray-200 border-t">
                 {/* {product.details.map((detail) => ( */}
-                <Disclosure as="div" key={selectedProduct._id}>
+                <Disclosure as="div" key={`taste-${selectedProduct._id}`}>
                   {({ open }) => (
                     <>
                       <h3>
@@ -289,7 +289,7 @@ export default function ProductOverview({
                     </>
                   )}
                 </Disclosure>
-                <Disclosure as="div" key={selectedProduct._id}>
+                <Disclosure as="div" key={`caffeine-${selectedProduct._id}`}>
                   {({ open }) => (
                     <>
                       <h3>
@@ -336,7 +336,7 @@ export default function ProductOverview({
                     </>
                   )}
                 </Disclosure>
-                <Disclosure as="div" key={selectedProduct._id}>
+                <Disclosure as="div" key={`color-${selectedProduct._id}`}>
                   {({ open }) => (
                     <>
                       <h3>

--- a/src/components/SearchPO.js
+++ b/src/components/SearchPO.js
@@ -247,7 +247,7 @@ export default function SearchPO({
               {/* FEATURES SECTION */}
               <div className="divide-y divide-gray-200 border-t">
                 {/* {product.details.map((detail) => ( */}
-                <Disclosure as="div" key={selectedProduct._id}>
+                <Disclosure as="div" key={`taste-${selectedProduct._id}`}>
                   {({ open }) => (
                     <>
                       <h3>
@@ -293,7 +293,7 @@ export default function SearchPO({
                     </>
                   )}
                 </Disclosure>
-                <Disclosure as="div" key={selectedProduct._id}>
+                <Disclosure as="div" key={`caffeine-${selectedProduct._id}`}>
                   {({ open }) => (
                     <>
                       <h3>
@@ -340,7 +340,7 @@ export default function SearchPO({
                     </>
                   )}
                 </Disclosure>
-                <Disclosure as="div" key={selectedProduct._id}>
+                <Disclosure as="div" key={`color-${selectedProduct._id}`}>
                   {({ open }) => (
                     <>
                       <h3>


### PR DESCRIPTION
was using product.id as a key in too many places. Added semantic tag to front of the id in the key.